### PR TITLE
kernel: mtd: backport extended dynamic partitions support

### DIFF
--- a/target/linux/generic/backport-5.4/417-v6.2-0001-mtd-core-simplify-a-bit-code-find-partition-matching.patch
+++ b/target/linux/generic/backport-5.4/417-v6.2-0001-mtd-core-simplify-a-bit-code-find-partition-matching.patch
@@ -1,0 +1,65 @@
+From 63db0cb35e1cb3b3c134906d1062f65513fdda2d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Tue, 4 Oct 2022 10:37:09 +0200
+Subject: [PATCH] mtd: core: simplify (a bit) code find partition-matching
+ dynamic OF node
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+1. Don't hardcode "partition-" string twice
+2. Use simpler logic & use ->name to avoid of_property_read_string()
+3. Use mtd_get_of_node() helper
+
+Cc: Christian Marangi <ansuelsmth@gmail.com>
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+Link: https://lore.kernel.org/linux-mtd/20221004083710.27704-1-zajec5@gmail.com
+---
+ drivers/mtd/mtdcore.c | 16 +++++++---------
+ 1 file changed, 7 insertions(+), 9 deletions(-)
+
+--- a/drivers/mtd/mtdcore.c
++++ b/drivers/mtd/mtdcore.c
+@@ -594,18 +594,16 @@ static void mtd_check_of_node(struct mtd
+ 	struct device_node *partitions, *parent_dn, *mtd_dn = NULL;
+ 	const char *pname, *prefix = "partition-";
+ 	int plen, mtd_name_len, offset, prefix_len;
+-	struct mtd_info *parent;
+ 	bool found = false;
+ 
+ 	/* Check if MTD already has a device node */
+-	if (dev_of_node(&mtd->dev))
++	if (mtd_get_of_node(mtd))
+ 		return;
+ 
+ 	/* Check if a partitions node exist */
+ 	if (!mtd_is_partition(mtd))
+ 		return;
+-	parent = mtd_get_master(mtd);
+-	parent_dn = of_node_get(dev_of_node(&parent->dev));
++	parent_dn = of_node_get(mtd_get_of_node(mtd_get_master(mtd)));
+ 	if (!parent_dn)
+ 		return;
+ 
+@@ -618,15 +616,15 @@ static void mtd_check_of_node(struct mtd
+ 
+ 	/* Search if a partition is defined with the same name */
+ 	for_each_child_of_node(partitions, mtd_dn) {
+-		offset = 0;
+-
+ 		/* Skip partition with no/wrong prefix */
+-		if (!of_node_name_prefix(mtd_dn, "partition-"))
++		if (!of_node_name_prefix(mtd_dn, prefix))
+ 			continue;
+ 
+ 		/* Label have priority. Check that first */
+-		if (of_property_read_string(mtd_dn, "label", &pname)) {
+-			of_property_read_string(mtd_dn, "name", &pname);
++		if (!of_property_read_string(mtd_dn, "label", &pname)) {
++			offset = 0;
++		} else {
++			pname = mtd_dn->name;
+ 			offset = prefix_len;
+ 		}
+ 

--- a/target/linux/generic/backport-5.4/417-v6.2-0002-mtd-core-try-to-find-OF-node-for-every-MTD-partition.patch
+++ b/target/linux/generic/backport-5.4/417-v6.2-0002-mtd-core-try-to-find-OF-node-for-every-MTD-partition.patch
@@ -1,0 +1,84 @@
+From ddb8cefb7af288950447ca6eeeafb09977dab56f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Tue, 4 Oct 2022 10:37:10 +0200
+Subject: [PATCH] mtd: core: try to find OF node for every MTD partition
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+So far this feature was limited to the top-level "nvmem-cells" node.
+There are multiple parsers creating partitions and subpartitions
+dynamically. Extend that code to handle them too.
+
+This allows finding partition-* node for every MTD (sub)partition.
+
+Random example:
+
+partitions {
+	compatible = "brcm,bcm947xx-cfe-partitions";
+
+	partition-firmware {
+		compatible = "brcm,trx";
+
+		partition-loader {
+		};
+	};
+};
+
+Cc: Christian Marangi <ansuelsmth@gmail.com>
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+Link: https://lore.kernel.org/linux-mtd/20221004083710.27704-2-zajec5@gmail.com
+---
+ drivers/mtd/mtdcore.c | 18 ++++++------------
+ 1 file changed, 6 insertions(+), 12 deletions(-)
+
+--- a/drivers/mtd/mtdcore.c
++++ b/drivers/mtd/mtdcore.c
+@@ -594,20 +594,22 @@ static void mtd_check_of_node(struct mtd
+ 	struct device_node *partitions, *parent_dn, *mtd_dn = NULL;
+ 	const char *pname, *prefix = "partition-";
+ 	int plen, mtd_name_len, offset, prefix_len;
+-	bool found = false;
+ 
+ 	/* Check if MTD already has a device node */
+ 	if (mtd_get_of_node(mtd))
+ 		return;
+ 
+-	/* Check if a partitions node exist */
+ 	if (!mtd_is_partition(mtd))
+ 		return;
++
+ 	parent_dn = of_node_get(mtd_get_of_node(mtd_get_master(mtd)));
+ 	if (!parent_dn)
+ 		return;
+ 
+-	partitions = of_get_child_by_name(parent_dn, "partitions");
++	if (mtd_is_partition(mtd_get_master(mtd)))
++		partitions = of_node_get(parent_dn);
++	else
++		partitions = of_get_child_by_name(parent_dn, "partitions");
+ 	if (!partitions)
+ 		goto exit_parent;
+ 
+@@ -631,19 +633,11 @@ static void mtd_check_of_node(struct mtd
+ 		plen = strlen(pname) - offset;
+ 		if (plen == mtd_name_len &&
+ 		    !strncmp(mtd->name, pname + offset, plen)) {
+-			found = true;
++			mtd_set_of_node(mtd, mtd_dn);
+ 			break;
+ 		}
+ 	}
+ 
+-	if (!found)
+-		goto exit_partitions;
+-
+-	/* Set of_node only for nvmem */
+-	if (of_device_is_compatible(mtd_dn, "nvmem-cells"))
+-		mtd_set_of_node(mtd, mtd_dn);
+-
+-exit_partitions:
+ 	of_node_put(partitions);
+ exit_parent:
+ 	of_node_put(parent_dn);

--- a/target/linux/generic/pending-5.4/480-mtd-set-rootfs-to-be-root-dev.patch
+++ b/target/linux/generic/pending-5.4/480-mtd-set-rootfs-to-be-root-dev.patch
@@ -20,7 +20,7 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
  #include <linux/nvmem-provider.h>
  
  #include <linux/mtd/mtd.h>
-@@ -762,6 +763,15 @@ int add_mtd_device(struct mtd_info *mtd)
+@@ -754,6 +755,15 @@ int add_mtd_device(struct mtd_info *mtd)
  	   of this try_ nonsense, and no bitching about it
  	   either. :) */
  	__module_get(THIS_MODULE);

--- a/target/linux/generic/pending-5.4/495-mtd-core-add-get_mtd_device_by_node.patch
+++ b/target/linux/generic/pending-5.4/495-mtd-core-add-get_mtd_device_by_node.patch
@@ -17,7 +17,7 @@ Reviewed-by: Miquel Raynal <miquel.raynal@bootlin.com>
 
 --- a/drivers/mtd/mtdcore.c
 +++ b/drivers/mtd/mtdcore.c
-@@ -1144,6 +1144,44 @@ out_unlock:
+@@ -1136,6 +1136,44 @@ out_unlock:
  }
  EXPORT_SYMBOL_GPL(get_mtd_device_nm);
  

--- a/target/linux/pistachio/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch
+++ b/target/linux/pistachio/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch
@@ -34,7 +34,7 @@ Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
  	mtd->type = MTD_NORFLASH;
 --- a/drivers/mtd/mtdcore.c
 +++ b/drivers/mtd/mtdcore.c
-@@ -842,6 +842,17 @@ out_error:
+@@ -834,6 +834,17 @@ out_error:
   */
  static void mtd_set_dev_defaults(struct mtd_info *mtd)
  {


### PR DESCRIPTION
This gets rid of "nvmem-cells" limitation. Dynamic partitions can be defined for any (sub)partitions layout.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
(cherry picked from commit 4eda414b09c790344e47c1cebe78e5433b4dc10d)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
