### PR TITLE
kernel: backport flow_dissect support for tag_brcm

### DIFF
--- a/target/linux/generic/backport-5.4/701-v5.7-net-dsa-Implement-flow-dissection-for-tag_brcm.c.patch
+++ b/target/linux/generic/backport-5.4/701-v5.7-net-dsa-Implement-flow-dissection-for-tag_brcm.c.patch
@@ -1,0 +1,62 @@
+From 52015366e361a88c569550a285c71f72bb095661 Mon Sep 17 00:00:00 2001
+From: Florian Fainelli <f.fainelli@gmail.com>
+Date: Sun, 22 Mar 2020 14:09:57 -0700
+Subject: [PATCH] net: dsa: Implement flow dissection for tag_brcm.c
+
+Provide a flow_dissect callback which returns the network offset and
+where to find the skb protocol, given the tags structure a common
+function works for both tagging formats that are supported.
+
+Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>
+Reviewed-by: Vivien Didelot <vivien.didelot@gmail.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ net/dsa/tag_brcm.c | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+--- a/net/dsa/tag_brcm.c
++++ b/net/dsa/tag_brcm.c
+@@ -144,6 +144,27 @@ static struct sk_buff *brcm_tag_rcv_ll(s
+ 
+ 	return skb;
+ }
++
++static int brcm_tag_flow_dissect(const struct sk_buff *skb, __be16 *proto,
++				 int *offset)
++{
++	/* We have been called on the DSA master network device after
++	 * eth_type_trans() which pulled the Ethernet header already.
++	 * Frames have one of these two layouts:
++	 * -----------------------------------
++	 * | MAC DA | MAC SA | 4b tag | Type | DSA_TAG_PROTO_BRCM
++	 * -----------------------------------
++	 * -----------------------------------
++	 * | 4b tag | MAC DA | MAC SA | Type | DSA_TAG_PROTO_BRCM_PREPEND
++	 * -----------------------------------
++	 * skb->data points 2 bytes before the actual Ethernet type field and
++	 * we have an offset of 4bytes between where skb->data and where the
++	 * payload starts.
++	 */
++	*offset = BRCM_TAG_LEN;
++	*proto = ((__be16 *)skb->data)[1];
++	return 0;
++}
+ #endif
+ 
+ #if IS_ENABLED(CONFIG_NET_DSA_TAG_BRCM)
+@@ -179,6 +200,7 @@ static const struct dsa_device_ops brcm_
+ 	.xmit	= brcm_tag_xmit,
+ 	.rcv	= brcm_tag_rcv,
+ 	.overhead = BRCM_TAG_LEN,
++	.flow_dissect = brcm_tag_flow_dissect,
+ };
+ 
+ DSA_TAG_DRIVER(brcm_netdev_ops);
+@@ -207,6 +229,7 @@ static const struct dsa_device_ops brcm_
+ 	.xmit	= brcm_tag_xmit_prepend,
+ 	.rcv	= brcm_tag_rcv_prepend,
+ 	.overhead = BRCM_TAG_LEN,
++	.flow_dissect = brcm_tag_flow_dissect,
+ };
+ 
+ DSA_TAG_DRIVER(brcm_prepend_netdev_ops);


### PR DESCRIPTION
This change helps BCM4908 SoC. It was capable of 940 Mb/s masq NAT while using iperf but users reported lower & unstable speeds for HTTP based tests.

For LibreSpeed tests this bumps NAT speed from ~930 Mb/s to ~990 Mb/s (not that this value seems real but speed bump definitely is).

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
