### PR TITLE
dnsmasq: Backport DHCPv6 server fix (CVE-2022-0934)

### DIFF
--- a/package/network/services/dnsmasq/patches/001-CVE-2022-0934-Fix-write-after-free-error-in-DHCPv6-code.patch
+++ b/package/network/services/dnsmasq/patches/001-CVE-2022-0934-Fix-write-after-free-error-in-DHCPv6-code.patch
@@ -1,0 +1,179 @@
+From 03345ecefeb0d82e3c3a4c28f27c3554f0611b39 Mon Sep 17 00:00:00 2001
+From: Simon Kelley <simon@thekelleys.org.uk>
+Date: Thu, 31 Mar 2022 21:35:20 +0100
+Subject: Fix write-after-free error in DHCPv6 code. CVE-2022-0934 refers.
+
+---
+ CHANGELOG     |  3 +++
+ src/rfc3315.c | 48 +++++++++++++++++++++++++++---------------------
+ 2 files changed, 30 insertions(+), 21 deletions(-)
+
+--- a/CHANGELOG
++++ b/CHANGELOG
+@@ -92,6 +92,9 @@ version 2.86
+ 	of filename). Thanks to Ed Wildgoose for the initial patch
+ 	and motivation for this.
+ 
++	Fix write-after-free error in DHCPv6 server code.
++	CVE-2022-0934 refers.
++	
+ 	
+ version 2.85
+         Fix problem with DNS retries in 2.83/2.84.
+--- a/src/rfc3315.c
++++ b/src/rfc3315.c
+@@ -33,9 +33,9 @@ struct state {
+   unsigned int mac_len, mac_type;
+ };
+ 
+-static int dhcp6_maybe_relay(struct state *state, void *inbuff, size_t sz, 
++static int dhcp6_maybe_relay(struct state *state, unsigned char *inbuff, size_t sz, 
+ 			     struct in6_addr *client_addr, int is_unicast, time_t now);
+-static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_t sz, int is_unicast, time_t now);
++static int dhcp6_no_relay(struct state *state, int msg_type, unsigned char *inbuff, size_t sz, int is_unicast, time_t now);
+ static void log6_opts(int nest, unsigned int xid, void *start_opts, void *end_opts);
+ static void log6_packet(struct state *state, char *type, struct in6_addr *addr, char *string);
+ static void log6_quiet(struct state *state, char *type, struct in6_addr *addr, char *string);
+@@ -104,12 +104,12 @@ unsigned short dhcp6_reply(struct dhcp_c
+ }
+ 
+ /* This cost me blood to write, it will probably cost you blood to understand - srk. */
+-static int dhcp6_maybe_relay(struct state *state, void *inbuff, size_t sz, 
++static int dhcp6_maybe_relay(struct state *state, unsigned char *inbuff, size_t sz, 
+ 			     struct in6_addr *client_addr, int is_unicast, time_t now)
+ {
+   void *end = inbuff + sz;
+   void *opts = inbuff + 34;
+-  int msg_type = *((unsigned char *)inbuff);
++  int msg_type = *inbuff;
+   unsigned char *outmsgtypep;
+   void *opt;
+   struct dhcp_vendor *vendor;
+@@ -259,15 +259,15 @@ static int dhcp6_maybe_relay(struct stat
+   return 1;
+ }
+ 
+-static int dhcp6_no_relay(struct state *state, int msg_type, void *inbuff, size_t sz, int is_unicast, time_t now)
++static int dhcp6_no_relay(struct state *state, int msg_type, unsigned char *inbuff, size_t sz, int is_unicast, time_t now)
+ {
+   void *opt;
+-  int i, o, o1, start_opts;
++  int i, o, o1, start_opts, start_msg;
+   struct dhcp_opt *opt_cfg;
+   struct dhcp_netid *tagif;
+   struct dhcp_config *config = NULL;
+   struct dhcp_netid known_id, iface_id, v6_id;
+-  unsigned char *outmsgtypep;
++  unsigned char outmsgtype;
+   struct dhcp_vendor *vendor;
+   struct dhcp_context *context_tmp;
+   struct dhcp_mac *mac_opt;
+@@ -296,12 +296,13 @@ static int dhcp6_no_relay(struct state *
+   v6_id.next = state->tags;
+   state->tags = &v6_id;
+ 
+-  /* copy over transaction-id, and save pointer to message type */
+-  if (!(outmsgtypep = put_opt6(inbuff, 4)))
++  start_msg = save_counter(-1);
++  /* copy over transaction-id */
++  if (!put_opt6(inbuff, 4))
+     return 0;
+   start_opts = save_counter(-1);
+-  state->xid = outmsgtypep[3] | outmsgtypep[2] << 8 | outmsgtypep[1] << 16;
+-   
++  state->xid = inbuff[3] | inbuff[2] << 8 | inbuff[1] << 16;
++    
+   /* We're going to be linking tags from all context we use. 
+      mark them as unused so we don't link one twice and break the list */
+   for (context_tmp = state->context; context_tmp; context_tmp = context_tmp->current)
+@@ -347,7 +348,7 @@ static int dhcp6_no_relay(struct state *
+       (msg_type == DHCP6REQUEST || msg_type == DHCP6RENEW || msg_type == DHCP6RELEASE || msg_type == DHCP6DECLINE))
+     
+     {  
+-      *outmsgtypep = DHCP6REPLY;
++      outmsgtype = DHCP6REPLY;
+       o1 = new_opt6(OPTION6_STATUS_CODE);
+       put_opt6_short(DHCP6USEMULTI);
+       put_opt6_string("Use multicast");
+@@ -619,11 +620,11 @@ static int dhcp6_no_relay(struct state *
+ 	struct dhcp_netid *solicit_tags;
+ 	struct dhcp_context *c;
+ 	
+-	*outmsgtypep = DHCP6ADVERTISE;
++	outmsgtype = DHCP6ADVERTISE;
+ 	
+ 	if (opt6_find(state->packet_options, state->end, OPTION6_RAPID_COMMIT, 0))
+ 	  {
+-	    *outmsgtypep = DHCP6REPLY;
++	    outmsgtype = DHCP6REPLY;
+ 	    state->lease_allocate = 1;
+ 	    o = new_opt6(OPTION6_RAPID_COMMIT);
+ 	    end_opt6(o);
+@@ -809,7 +810,7 @@ static int dhcp6_no_relay(struct state *
+ 	int start = save_counter(-1);
+ 
+ 	/* set reply message type */
+-	*outmsgtypep = DHCP6REPLY;
++	outmsgtype = DHCP6REPLY;
+ 	state->lease_allocate = 1;
+ 
+ 	log6_quiet(state, "DHCPREQUEST", NULL, ignore ? _("ignored") : NULL);
+@@ -924,7 +925,7 @@ static int dhcp6_no_relay(struct state *
+ 	int address_assigned = 0;
+ 
+ 	/* set reply message type */
+-	*outmsgtypep = DHCP6REPLY;
++	outmsgtype = DHCP6REPLY;
+ 	
+ 	log6_quiet(state, msg_type == DHCP6RENEW ? "DHCPRENEW" : "DHCPREBIND", NULL, NULL);
+ 
+@@ -1057,7 +1058,7 @@ static int dhcp6_no_relay(struct state *
+ 	int good_addr = 0;
+ 
+ 	/* set reply message type */
+-	*outmsgtypep = DHCP6REPLY;
++	outmsgtype = DHCP6REPLY;
+ 	
+ 	log6_quiet(state, "DHCPCONFIRM", NULL, NULL);
+ 	
+@@ -1121,7 +1122,7 @@ static int dhcp6_no_relay(struct state *
+ 	log6_quiet(state, "DHCPINFORMATION-REQUEST", NULL, ignore ? _("ignored") : state->hostname);
+ 	if (ignore)
+ 	  return 0;
+-	*outmsgtypep = DHCP6REPLY;
++	outmsgtype = DHCP6REPLY;
+ 	tagif = add_options(state, 1);
+ 	break;
+       }
+@@ -1130,7 +1131,7 @@ static int dhcp6_no_relay(struct state *
+     case DHCP6RELEASE:
+       {
+ 	/* set reply message type */
+-	*outmsgtypep = DHCP6REPLY;
++	outmsgtype = DHCP6REPLY;
+ 
+ 	log6_quiet(state, "DHCPRELEASE", NULL, NULL);
+ 
+@@ -1195,7 +1196,7 @@ static int dhcp6_no_relay(struct state *
+     case DHCP6DECLINE:
+       {
+ 	/* set reply message type */
+-	*outmsgtypep = DHCP6REPLY;
++	outmsgtype = DHCP6REPLY;
+ 	
+ 	log6_quiet(state, "DHCPDECLINE", NULL, NULL);
+ 
+@@ -1275,7 +1276,12 @@ static int dhcp6_no_relay(struct state *
+       }
+ 
+     }
+-  
++
++  /* Fill in the message type. Note that we store the offset,
++     not a direct pointer, since the packet memory may have been 
++     reallocated. */
++  ((unsigned char *)(daemon->outpacket.iov_base))[start_msg] = outmsgtype;
++
+   log_tags(tagif, state->xid);
+   log6_opts(0, state->xid, daemon->outpacket.iov_base + start_opts, daemon->outpacket.iov_base + save_counter(-1));
+   


### PR DESCRIPTION
This backports a commit from upstream dnsmasq to fix CVE-2022-0934.

CVE-2022-0934 description:
A single-byte, non-arbitrary write/use-after-free flaw was found in dnsmasq. This flaw allows an attacker who sends a crafted packet processed by dnsmasq, potentially causing a denial of service.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
(cherry picked from commit 002a99eccd75fb653163bae0a1132bd4f494e7ad)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
