### PR TITLE
rampis: fix Reference to non-existent node for GB-PC2

### DIFF
--- a/target/linux/ramips/dts/mt7621_gnubee_gb-pc2.dts
+++ b/target/linux/ramips/dts/mt7621_gnubee_gb-pc2.dts
@@ -119,8 +119,7 @@
 	label = "ethyellow";
 	phy-handle = <&ethphy5>;
 
-	nvmem-cells = <&macaddr_factory_e000>;
-	nvmem-cell-names = "mac-address";
+	mtd-mac-address = <&factory 0xe000>;
 };
 
 &mdio {


### PR DESCRIPTION
Fix cannot build: Reference to non-existent node or label "macaddr_factory_e000" dtb compilation error.

The cherry-pick had to be reworked to use the old mtd-mac-address way as openwrt-21.02 still wasn't migrated to nvmem implementation.

Fixes: d604032c2a50 ("ramips: fix GB-PC1 and GB-PC2 device support") Fixes: #11654
Fixes: #11385
Signed-off-by: Arınç ÜNAL <arinc.unal@arinc9.com>
[ rework commit message, add more fixes tag ]
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
