### PR TITLE
kernel: expose (unhide) CONFIG_ASN1 as ksmbd requirement

### DIFF
--- a/target/linux/generic/hack-5.4/252-init-Kconfig-make-ASN1-explicitly-selectable-unhide-.patch
+++ b/target/linux/generic/hack-5.4/252-init-Kconfig-make-ASN1-explicitly-selectable-unhide-.patch
@@ -1,0 +1,30 @@
+From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal@milecki.pl>
+Date: Mon, 23 Jan 2023 12:24:12 +0100
+Subject: [PATCH] init/Kconfig: make ASN1 explicitly selectable (unhide it)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Kernel developers assumed ASN1 symbol may be needed only by in-kernel
+code and they made it hidden. It is actually used by ksmbd version being
+developed in GitHub (there is also upstream one since Linux 5.15).
+
+To allow building ksmbd from GitHub cleanly allow selecting its
+dependency (CONFIG_ASN1) explicitly by unhiding it.
+
+Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
+---
+ init/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/init/Kconfig
++++ b/init/Kconfig
+@@ -2249,7 +2249,7 @@ config PADATA
+ 	bool
+ 
+ config ASN1
+-	tristate
++	tristate "ASN.1 grammar compiler"
+ 	help
+ 	  Build a simple ASN.1 grammar compiler that produces a bytecode output
+ 	  that can be interpreted by the ASN.1 stream decoder and used to


### PR DESCRIPTION
OpenWrt provides kmod-asn1-decoder for CONFIG_ASN1 but selecting it doesn't really work as expected. Kernel symbol is hidden and can be actually selected only as a dependency. That works well for in-kernel stuff but fails for external modules requiring ASN1 like ksmbd.

Modify kernel Kconfig to make CONFIG_ASN1 always selectable. It's required to satisfy ksmbd dependencies cleanly (without hack like selecting unrelated modules).

Link: http://lists.openwrt.org/pipermail/openwrt-devel/2023-January/040298.html
Signed-off-by: Rafał Miłecki <rafal@milecki.pl>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
