### PR TITLE
kernel: allow adding devices without hw offload to a hw flowtable

### DIFF
--- a/target/linux/generic/pending-5.15/701-netfilter-nf_tables-ignore-EOPNOTSUPP-on-flowtable-d.patch
+++ b/target/linux/generic/pending-5.15/701-netfilter-nf_tables-ignore-EOPNOTSUPP-on-flowtable-d.patch
@@ -1,0 +1,29 @@
+From: Felix Fietkau <nbd@nbd.name>
+Date: Thu, 31 Aug 2023 21:48:38 +0200
+Subject: [PATCH] netfilter: nf_tables: ignore -EOPNOTSUPP on flowtable device
+ offload setup
+
+On many embedded devices, it is common to configure flowtable offloading for
+a mix of different devices, some of which have hardware offload support and
+some of which don't.
+The current code limits the ability of user space to properly set up such a
+configuration by only allowing adding devices with hardware offload support to
+a offload-enabled flowtable.
+Given that offload-enabled flowtables also imply fallback to pure software
+offloading, this limitation makes little sense.
+Fix it by not bailing out when the offload setup returns -EOPNOTSUPP
+
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+---
+
+--- a/net/netfilter/nf_tables_api.c
++++ b/net/netfilter/nf_tables_api.c
+@@ -7729,7 +7729,7 @@ static int nft_register_flowtable_net_ho
+ 		err = flowtable->data.type->setup(&flowtable->data,
+ 						  hook->ops.dev,
+ 						  FLOW_BLOCK_BIND);
+-		if (err < 0)
++		if (err < 0 && err != -EOPNOTSUPP)
+ 			goto err_unregister_net_hooks;
+ 
+ 		err = nf_register_net_hook(net, &hook->ops);


### PR DESCRIPTION
This allows supporting a mix of devices with or without hw offloading support

Signed-off-by: Felix Fietkau <nbd@nbd.name>
(cherry picked from commit c5b7be83168644f3cfadc7b0fbe471e1664b1069)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
