### PR TITLE
package: base-files: turn error into warning

### DIFF
--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -80,8 +80,7 @@ BEGIN {
 	}
 
 	if (ipaddr > start && ipaddr < end) {
-		print "ipaddr inside range" > "/dev/stderr"
-		exit(1)
+		print "warning: ipaddr inside range - this might not be supported in future releases of Openwrt" > "/dev/stderr"
 	}
 
 	print "START="int2ip(start)


### PR DESCRIPTION
Some users have their routers configured to supply a DHCP range that includes the local interface address.
That worked with dnsmasq because it automatically skips the local address.

Re-enable those existing configurations for the release and hint at possible future problems.


[ wrap commit description and remove unecessary text ]

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
