### PR TITLE
generic: add patch for GPON-ONU-34-20BI quirk

### DIFF
--- a/target/linux/generic/backport-5.15/798-net-next-net-sfp-add-quirk-for-Fiberstone-GPON-ONU-34-20BI.patch
+++ b/target/linux/generic/backport-5.15/798-net-next-net-sfp-add-quirk-for-Fiberstone-GPON-ONU-34-20BI.patch
@@ -1,0 +1,34 @@
+From d387e34fec407f881fdf165b5d7ec128ebff362f Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 19 Sep 2023 14:47:20 +0200
+Subject: [PATCH] net: sfp: add quirk for Fiberstone GPON-ONU-34-20BI
+
+Fiberstone GPON-ONU-34-20B can operate at 2500base-X, but report 1.2GBd
+NRZ in their EEPROM.
+
+The module also require the ignore tx fault fixup similar to Huawei MA5671A
+as it gets disabled on error messages with serial redirection enabled.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+Link: https://lore.kernel.org/r/20230919124720.8210-1-ansuelsmth@gmail.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/phy/sfp.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -368,6 +368,13 @@ static const struct sfp_quirk sfp_quirks
+ 		.modes = sfp_quirk_2500basex,
+ 		.fixup = sfp_fixup_long_startup,
+ 	}, {
++		// Fiberstore GPON-ONU-34-20BI can operate at 2500base-X, but report 1.2GBd
++		// NRZ in their EEPROM
++		.vendor = "FS",
++		.part = "GPON-ONU-34-20BI",
++		.modes = sfp_quirk_2500basex,
++		.fixup = sfp_fixup_ignore_tx_fault,
++	}, {
+ 		.vendor = "HALNy",
+ 		.part = "HL-GSFP",
+ 		.fixup = sfp_fixup_halny_gsfp,

--- a/target/linux/generic/hack-5.15/790-SFP-GE-T-ignore-TX_FAULT.patch
+++ b/target/linux/generic/hack-5.15/790-SFP-GE-T-ignore-TX_FAULT.patch
@@ -26,7 +26,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -383,6 +383,11 @@ static const struct sfp_quirk sfp_quirks
+@@ -390,6 +390,11 @@ static const struct sfp_quirk sfp_quirks
  		.modes = sfp_quirk_2500basex,
  		.fixup = sfp_fixup_ignore_tx_fault,
  	}, {
@@ -38,7 +38,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		// Lantech 8330-262D-E can operate at 2500base-X, but
  		// incorrectly report 2500MBd NRZ in their EEPROM
  		.vendor = "Lantech",
-@@ -2312,7 +2317,8 @@ static void sfp_sm_main(struct sfp *sfp,
+@@ -2319,7 +2324,8 @@ static void sfp_sm_main(struct sfp *sfp,
  			 * or t_start_up, so assume there is a fault.
  			 */
  			sfp_sm_fault(sfp, SFP_S_INIT_TX_FAULT,
@@ -48,7 +48,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		} else if (event == SFP_E_TIMEOUT || event == SFP_E_TX_CLEAR) {
  	init_done:
  			sfp->sm_phy_retries = R_PHY_RETRY;
-@@ -2535,10 +2541,12 @@ static void sfp_check_state(struct sfp *
+@@ -2542,10 +2548,12 @@ static void sfp_check_state(struct sfp *
  	mutex_lock(&sfp->st_mutex);
  	state = sfp_get_state(sfp);
  	changed = state ^ sfp->state;

--- a/target/linux/realtek/patches-5.15/710-net-phy-sfp-re-probe-modules-on-DEV_UP-event.patch
+++ b/target/linux/realtek/patches-5.15/710-net-phy-sfp-re-probe-modules-on-DEV_UP-event.patch
@@ -10,7 +10,7 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -2153,6 +2153,13 @@ static void sfp_sm_module(struct sfp *sf
+@@ -2160,6 +2160,13 @@ static void sfp_sm_module(struct sfp *sf
  		return;
  	}
  

--- a/target/linux/realtek/patches-5.15/712-net-phy-sfp-add-support-for-SMBus.patch
+++ b/target/linux/realtek/patches-5.15/712-net-phy-sfp-add-support-for-SMBus.patch
@@ -10,7 +10,7 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -549,32 +549,72 @@ static int sfp_i2c_write(struct sfp *sfp
+@@ -556,32 +556,72 @@ static int sfp_i2c_write(struct sfp *sfp
  	return ret == ARRAY_SIZE(msgs) ? len : 0;
  }
  


### PR DESCRIPTION
Backport patch merged upstream adding quirk for SFP GPON-ONU-34-20BI.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
(cherry picked from commit 86dadeba482e2ed41f1ccc95fc7739d85a5709c0)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
