### PR TITLE
ath79: wpj563: enable 2nd USB controller

### DIFF
--- a/target/linux/ath79/dts/qca9563_compex_wpj563.dts
+++ b/target/linux/ath79/dts/qca9563_compex_wpj563.dts
@@ -131,6 +131,14 @@
 	status = "okay";
 };
 
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
 &wmac {
 	status = "okay";
 


### PR DESCRIPTION
The compex WPJ563 actually has both usb controllers wired:

usb0 --> pci-e slot
usb1 --> pin header

As the board exposes it for generic use, enable this controller too.

fixes: #13650
Signed-off-by: Koen Vandeputte <koen.vandeputte@citymesh.com>
(cherry picked from commit 9188c77cbee55a933d0fa75c74e175fbc52c556d)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
