### PR TITLE
mediatek: add label-mac for GL.iNet GL-MT3000

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
@@ -7,6 +7,7 @@
 	compatible = "glinet,gl-mt3000", "mediatek,mt7981";
 
 	aliases {
+		label-mac-device = &gmac0;
 		led-boot = &led_lightblue;
 		led-failsafe = &led_lightblue;
 		led-running = &led_white;


### PR DESCRIPTION
The MAC-address of gmac0 matches the one printed on the bottom label.

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit ae500e62e2938e112ae1fc6aa7389e8c7b784b13)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
