### PR TITLE
image: fix image generation within ImageBuilder

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -277,11 +277,13 @@ endef
 define Image/Manifest
 	$(call opkg,$(TARGET_DIR_ORIG)) list-installed > \
 		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).manifest
+ifndef IB
 	$(if $(CONFIG_JSON_CYCLONEDX_SBOM), \
 		$(SCRIPT_DIR)/package-metadata.pl imgcyclonedxsbom \
 		$(TMP_DIR)/.packageinfo \
 		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).manifest > \
 		$(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED)).bom.cdx.json)
+endif
 endef
 
 define Image/gzip-ext4-padded-squashfs


### PR DESCRIPTION
Changes introduced in commit d604a07225c5 ("build: add CycloneDX SBOM JSON support") broke ImageBuilder:

  Cannot open '/openwrt-imagebuilder-ath79-generic.Linux-x86_64/tmp/.packageinfo': No such file or directory

So lets fix it by wrapping the BOM generation behind condition of IB feature check.

Fixes: #13881
Fixes: d604a07225c5 ("build: add CycloneDX SBOM JSON support")
Signed-off-by: Petr Štetiar <ynezz@true.cz>
(cherry picked from commit c4259a658673cc1a02ed17bfa8e94de17de00ad2)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
