### PR TITLE
ramips: yuncore_g720: fix buttons

### DIFF
--- a/target/linux/ramips/dts/mt7621_yuncore_g720.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_g720.dts
@@ -33,9 +33,15 @@
 	keys {
 		compatible = "gpio-keys";
 
+		wps {
+			label = "wps";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
 		reset {
 			label = "reset";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};


### PR DESCRIPTION
Turns out the device got two buttons, while the currently listed on is actually WPS, and the other (will hidden) button is intended as RESET. Update DT accordingly.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
(cherry picked from commit 646ebbd32ca4d776c64c31e85c08dc72fec25d7d)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
